### PR TITLE
Format display and calculator description

### DIFF
--- a/CardinalCalculator/Base.lproj/Main.storyboard
+++ b/CardinalCalculator/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="8Ig-mv-Gol">
                                                 <rect key="frame" x="0.0" y="0.0" width="528" height="39"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="GCQ-hq-7Ei">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="GCQ-hq-7Ei">
                                                         <rect key="frame" x="0.0" y="0.0" width="528" height="39"/>
                                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="40"/>
@@ -44,7 +44,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="BuX-k4-2CK">
                                                 <rect key="frame" x="0.0" y="42" width="528" height="39.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="VrH-3Z-27F">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="VrH-3Z-27F">
                                                         <rect key="frame" x="0.0" y="0.0" width="528" height="39.5"/>
                                                         <color key="backgroundColor" red="1" green="0.80000001190000003" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="40"/>
@@ -641,7 +641,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="2OM-fL-PKo">
                                                 <rect key="frame" x="0.0" y="0.0" width="288" height="73.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="PIw-pe-Sxr">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="right" lineBreakMode="tailTruncation" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="PIw-pe-Sxr">
                                                         <rect key="frame" x="0.0" y="0.0" width="288" height="73.5"/>
                                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="40"/>
@@ -653,7 +653,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="kUj-A5-p4D">
                                                 <rect key="frame" x="0.0" y="76.5" width="288" height="73.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="So1-Ff-UNB">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="So1-Ff-UNB">
                                                         <rect key="frame" x="0.0" y="0.0" width="288" height="73.5"/>
                                                         <color key="backgroundColor" red="1" green="0.80000001190000003" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="40"/>
@@ -927,11 +927,27 @@
                             <mask key="subviews">
                                 <exclude reference="tgI-fL-Xgn"/>
                             </mask>
+                            <mask key="constraints">
+                                <exclude reference="DqM-aE-gTf"/>
+                                <exclude reference="XNe-y3-eDD"/>
+                                <exclude reference="kJ8-MG-SFz"/>
+                                <exclude reference="rsy-Gz-r4G"/>
+                            </mask>
                         </variation>
                         <variation key="heightClass=compact">
                             <mask key="subviews">
                                 <include reference="tgI-fL-Xgn"/>
                                 <exclude reference="thU-ZR-ShK"/>
+                            </mask>
+                            <mask key="constraints">
+                                <include reference="DqM-aE-gTf"/>
+                                <include reference="XNe-y3-eDD"/>
+                                <include reference="kJ8-MG-SFz"/>
+                                <exclude reference="WnI-1a-lbj"/>
+                                <exclude reference="fk9-gR-IyS"/>
+                                <exclude reference="gqm-25-a3k"/>
+                                <exclude reference="UT1-Ki-KOv"/>
+                                <include reference="rsy-Gz-r4G"/>
                             </mask>
                         </variation>
                     </view>

--- a/CardinalCalculator/CalculatorBrain.swift
+++ b/CardinalCalculator/CalculatorBrain.swift
@@ -98,7 +98,12 @@ struct CalculatorBrain {
     ///
     /// - Parameter operand: new operand.
     mutating func setOperand(_ operand: Double) {
-        accumulator = (operand, "\(operand)")
+        let numberFormatter = NumberFormatter()
+        numberFormatter.maximumFractionDigits = 6
+        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.minimumIntegerDigits = 1
+        
+        accumulator = (operand, "\(numberFormatter.string(from: operand as NSNumber)!)")
     }
     
     /// Returns calculator's current result or accumulated result if `resultIsPending` is true.

--- a/CardinalCalculator/ViewController.swift
+++ b/CardinalCalculator/ViewController.swift
@@ -38,7 +38,12 @@ class ViewController: UIViewController {
             return Double(display.text!)! // Assume text label is always a double
         }
         set {
-            display.text = String(newValue)
+            let numberFormatter = NumberFormatter()
+            numberFormatter.maximumFractionDigits = 6
+            numberFormatter.minimumFractionDigits = 0
+            numberFormatter.minimumIntegerDigits = 1
+            
+            display.text = numberFormatter.string(from: newValue as NSNumber)
         }
     }
     


### PR DESCRIPTION
- Added NumberFormatter to both the CalculatorBrain description and calculator
  display that only shows 6 digits after the decimal point and removes the
  trailing fractional ".0" part on integer numbers.